### PR TITLE
fix: atualizar caminhos para o arquivo manifest.json no fluxo de trab…

### DIFF
--- a/.github/workflows/kubex_go_release.yml
+++ b/.github/workflows/kubex_go_release.yml
@@ -60,15 +60,15 @@ jobs:
       - name: Load Module Manifest
         id: manifest
         run: |
-          if [[ ! -f "$(git rev-parse --show-toplevel)/internal/module/info/manifest.json" ]]; then
-            echo "❌ internal/module/info/manifest.json not found"
+          if [[ ! -f "$(git rev-parse --show-toplevel)/info/manifest.json" ]]; then
+            echo "❌ info/manifest.json not found"
             exit 1
           fi
 
           # Extract module information
-          MODULE_NAME=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.bin // .name // "unknown"')
-          MODULE_VERSION=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.version // "0.0.0"')
-          PLATFORMS=$(cat $(git rev-parse --show-toplevel)/internal/module/info/manifest.json | jq -r '.platforms[]?' | tr '\n' ' ' | sed 's/ $//')
+          MODULE_NAME=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.bin // .name // "unknown"')
+          MODULE_VERSION=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.version // "0.0.0"')
+          PLATFORMS=$(cat $(git rev-parse --show-toplevel)/info/manifest.json | jq -r '.platforms[]?' | tr '\n' ' ' | sed 's/ $//')
           # Validate required fields
           if [[ "$MODULE_NAME" == "unknown" || "$MODULE_NAME" == "null" ]]; then
             echo "❌ Module name not found in manifest (bin or name field required)"
@@ -123,7 +123,7 @@ jobs:
             echo "   Git Tag: $TAG_VERSION"
             echo "   Manifest: $MANIFEST_VERSION"
             echo ""
-            echo "Please update internal/module/info/manifest.json version to match the git tag."
+            echo "Please update info/manifest.json version to match the git tag."
             echo "Expected: \"version\": \"$TAG_CLEAN\""
             echo ""
             echo "🛑 Workflow will skip remaining steps for safety."
@@ -250,7 +250,7 @@ jobs:
           echo "**Git Tag**: ${{ steps.version.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "**Manifest**: v${{ steps.manifest.outputs.manifest-version }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Please update \`internal/module/info/manifest.json\` version to match the git tag before releasing." >> $GITHUB_STEP_SUMMARY
+          echo "Please update \`info/manifest.json\` version to match the git tag before releasing." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "Expected change in manifest:" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY

--- a/support/apply_manifest.sh
+++ b/support/apply_manifest.sh
@@ -23,7 +23,7 @@ _PRIVATE_REPOSITORY="${_PRIVATE_REPOSITORY:-}"
 _VERSION_GO="${_VERSION_GO:-}"
 _PLATFORMS_SUPPORTED="${_PLATFORMS_SUPPORTED:-}"
 
-# _MANIFEST_SUBPATH=${_MANIFEST_SUBPATH:-'internal/module/info/manifest.json'}
+# _MANIFEST_SUBPATH=${_MANIFEST_SUBPATH:-'info/manifest.json'}
 _MANIFEST_SUBPATH=${_MANIFEST_SUBPATH:-'info/manifest.json'}
 
 __get_values_from_manifest() {

--- a/support/validate.sh
+++ b/support/validate.sh
@@ -43,7 +43,7 @@ validate_versions() {
 
     # Validate other dependencies from manifest
     local dependencies manifest_file
-    manifest_file="${_ROOT_DIR:-$(git rev-parse --show-toplevel)}/${_MANIFEST_SUBPATH:-/internal/module/info/manifest.json}"
+    manifest_file="${_ROOT_DIR:-$(git rev-parse --show-toplevel)}/${_MANIFEST_SUBPATH:-/info/manifest.json}"
 
     if [[ -f "${manifest_file}" ]]; then
         mapfile -t dependencies < <(jq -r '.dependencies[]?' "${manifest_file}")


### PR DESCRIPTION
This pull request updates all references to the module manifest file, moving it from `internal/module/info/manifest.json` to `info/manifest.json` across the workflow and support scripts. This ensures consistency and that all scripts and workflows use the new manifest location.

**Manifest file path update:**

* Updated all references in `.github/workflows/kubex_go_release.yml` to use `info/manifest.json` instead of `internal/module/info/manifest.json`, including loading, extracting information, error messages, and summary output. [[1]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL63-R71) [[2]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL126-R126) [[3]](diffhunk://#diff-913fe946b3b3440e125256a3653b80a714a1b6126042f4f0a90cef41fc859bbdL253-R253)
* Changed the default manifest path in `support/apply_manifest.sh` to `info/manifest.json`.
* Updated the default manifest path in `support/validate.sh` to `info/manifest.json`.