### PR TITLE
Kubex master unification

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Kubex Go Dist CI](https://github.com/kubex-ecosystem/logz/actions/workflows/kubex_go_release.yml/badge.svg)](https://github.com/kubex-ecosystem/logz/actions/workflows/kubex_go_release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Go Version](https://img.shields.io/badge/go-%3E=1.21-blue)](go.mod)
-[![Releases](https://img.shields.io/github/v/release/rafa-mori/logz?include_prereleases)](https://github.com/kubex-ecosystem/logz/releases)
+[![Releases](https://img.shields.io/github/v/release/kubex-ecosystem/logz?include_prereleases)](https://github.com/kubex-ecosystem/logz/releases)
 
 ---
 
@@ -744,7 +744,7 @@ Rafael Mori
 - 📧 [Email](mailto:faelmori@gmail.com)
 - 💼 Follow me on GitHub:
   - [faelmori](https://github.com/faelmori)
-  - [rafa-mori](https://github.com/kubex-ecosystem)
+  - [kubex-ecosystem](https://github.com/kubex-ecosystem)
 
 ---
 

--- a/docs/README.pt-BR.md
+++ b/docs/README.pt-BR.md
@@ -495,6 +495,6 @@ Rafael Mori
 - 📧 [Email](mailto:faelmori@gmail.com)
 - 💼 Follow me on GitHub:
   - [faelmori](https://github.com/faelmori)
-  - [rafa-mori](https://github.com/kubex-ecosystem)
+  - [kubex-ecosystem](https://github.com/kubex-ecosystem)
 
 Adoraria ouvir sobre novas oportunidades de trabalho ou colaborações. Se você gostou desse projeto, não hesite em entrar em contato comigo!

--- a/info/manifest.json
+++ b/info/manifest.json
@@ -13,7 +13,7 @@
   "main": "cmd/main.go",
   "bin": "logz",
   "author": "Rafael Mori <faelmori@gmail.com>",
-  "organization": "rafa-mori",
+  "organization": "kubex-ecosystem",
   "license": "MIT",
   "keywords": [
     "logz",

--- a/support/apply_manifest.sh
+++ b/support/apply_manifest.sh
@@ -33,14 +33,14 @@ __get_values_from_manifest() {
   # shellcheck disable=SC2005
   _APP_NAME="$(jq -r '.bin' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "$(basename "${_ROOT_DIR:-}")")"
   _DESCRIPTION="$(jq -r '.description' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "No description provided.")"
-  _OWNER="$(jq -r '.organization' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "rafa-mori")"
+  _OWNER="$(jq -r '.organization' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "kubex-ecosystem")"
   _OWNER="${_OWNER,,}"  # Converts to lowercase
   _BINARY_NAME="${_APP_NAME}"
   _PROJECT_NAME="$(jq -r '.name' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "$_APP_NAME")"
   _AUTHOR="$(jq -r '.author' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "Rafa Mori")"
   _VERSION=$(jq -r '.version' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "v0.0.0")
   _LICENSE="$(jq -r '.license' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "MIT")"
-  _REPOSITORY="$(jq -r '.repository' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "rafa-mori/${_APP_NAME}")"
+  _REPOSITORY="$(jq -r '.repository' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "kubex-ecosystem/${_APP_NAME}")"
   _PRIVATE_REPOSITORY="$(jq -r '.private' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "false")"
   _VERSION_GO=$(grep '^go ' "$_ROOT_DIR/go.mod" | awk '{print $2}')
   _PLATFORMS_SUPPORTED="$(jq -r '.platforms[]' "$_ROOT_DIR/$_MANIFEST_SUBPATH" 2>/dev/null || echo "linux, macOS, windows")"

--- a/support/docs/mkdocs.yml
+++ b/support/docs/mkdocs.yml
@@ -1,16 +1,16 @@
 site_name: TimeCraft AI
-site_url: https://rafa-mori.github.io/timecraft/
-site_description: 'Advanced time series analysis, database integration, and task automation with dynamic notifications and powerful CLI'
-site_author: 'Rafael Mori'
+site_url: https://kubex-ecosystem.github.io/timecraft/
+site_description: "Advanced time series analysis, database integration, and task automation with dynamic notifications and powerful CLI"
+site_author: "Rafael Mori"
 
-repo_name: 'rafa-mori/timecraft'
+repo_name: "kubex-ecosystem/timecraft"
 repo_url: https://github.com/kubex-ecosystem/timecraft
 
 theme:
   name: material
   palette:
-    primary: 'indigo'
-    accent: 'indigo'
+    primary: "indigo"
+    accent: "indigo"
   features:
     - navigation.tabs
     - navigation.top
@@ -58,7 +58,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.magiclink:
       repo_url_shorthand: true
-      user: rafa-mori
+      user: kubex-ecosystem
       repo: timecraft
   - pymdownx.mark
   - pymdownx.smartsymbols
@@ -76,22 +76,22 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Documentation:
-    - Getting Started:
-      - README: README.en.md
-      - Installation: INSTALL.md
-      - AI Integration: INSTALL_AI.md
-    - User Guide:
-      - README (Portuguese): README.pt-BR.md
+      - Getting Started:
+          - README: README.en.md
+          - Installation: INSTALL.md
+          - AI Integration: INSTALL_AI.md
+      - User Guide:
+          - README (Portuguese): README.pt-BR.md
   - Community:
-    - Contributing: CONTRIBUTING.md
-    - Code of Conduct: CODE_OF_CONDUCT.md
-    - Support: SUPPORT.md
-    - Authors: AUTHORS.md
+      - Contributing: CONTRIBUTING.md
+      - Code of Conduct: CODE_OF_CONDUCT.md
+      - Support: SUPPORT.md
+      - Authors: AUTHORS.md
   - Project Info:
-    - License: LICENSE
-    - Notice: NOTICE.md
-    - Security Policy: SECURITY.md
-    - Changelog: CHANGELOG.md
+      - License: LICENSE
+      - Notice: NOTICE.md
+      - Security Policy: SECURITY.md
+      - Changelog: CHANGELOG.md
 
 extra:
   social:
@@ -99,7 +99,7 @@ extra:
       link: https://github.com/kubex-ecosystem/timecraft
       name: TimeCraft AI on GitHub
     - icon: fontawesome/brands/linkedin
-      link: https://www.linkedin.com/in/rafa-mori/
+      link: https://www.linkedin.com/in/kubex-ecosystem/
       name: Rafael Mori on LinkedIn
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/faelOmori
@@ -109,7 +109,6 @@ extra:
   analytics:
     provider: google
     property: ${G-7HLY17F3DK}
-
 # plugins:
 #   - search:
 #       lang: en

--- a/support/go_version.sh
+++ b/support/go_version.sh
@@ -54,7 +54,7 @@ auto_install_go_with_gosetup() {
   local required_version go_setup_url
 
   required_version="${1:-$(get_required_go_version "go.mod")}"
-  go_setup_url='https://raw.githubusercontent.com/rafa-mori/gosetup/main/go.sh'
+  go_setup_url='https://raw.githubusercontent.com/kubex-ecosystem/gosetup/main/go.sh'
 
   log info "Installing Go ${required_version} using GoSetup..."
 

--- a/support/validate.sh
+++ b/support/validate.sh
@@ -6,7 +6,7 @@
 source "$(dirname "${BASH_SOURCE[0]}")/go_version.sh"
 
 validate_versions() {
-    local go_setup_url='https://raw.githubusercontent.com/rafa-mori/gosetup/main/go.sh'
+    local go_setup_url='https://raw.githubusercontent.com/kubex-ecosystem/gosetup/main/go.sh'
     local current_version required_version
 
     # Use modular functions for version checking


### PR DESCRIPTION
This pull request updates project references from the old `rafa-mori` namespace to the new `kubex-ecosystem` namespace across documentation, configuration, and scripts. This ensures consistency in project ownership, repository URLs, and related metadata throughout the codebase and documentation.

**Repository and Organization Updates:**

* Updated all occurrences of the organization or user from `rafa-mori` to `kubex-ecosystem` in `manifest.json`, `README.md`, and related documentation files. [[1]](diffhunk://#diff-bdefd119a1674ff3e56f23cb402a9c026eb161325391fae82d289e3dbe94b28aL16-R16) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L6-R6) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L747-R747) [[4]](diffhunk://#diff-7ec39998b17912f2773e182c959c89a8ba89fdc2280235633f079d637321bec7L498-R498)

**Documentation and Metadata:**

* Changed documentation URLs, repository names, and author links in `mkdocs.yml` and `README.md` to point to `kubex-ecosystem` and updated related LinkedIn and repo references. [[1]](diffhunk://#diff-9b024ecd58897fdcbf4dfd6615d57aac152217b518e3c3593b239c8dc8692583L2-R13) [[2]](diffhunk://#diff-9b024ecd58897fdcbf4dfd6615d57aac152217b518e3c3593b239c8dc8692583L61-R61) [[3]](diffhunk://#diff-9b024ecd58897fdcbf4dfd6615d57aac152217b518e3c3593b239c8dc8692583L102-R102)

**Script and Automation Updates:**

* Updated default organization and repository values in shell scripts (`apply_manifest.sh`, `go_version.sh`, `validate.sh`) to use `kubex-ecosystem` and point to the new Go setup script location. [[1]](diffhunk://#diff-b6dd5e75d2e1e079b3b58df802a7fdecc2a9270a263fad4093a17ef39b613a0cL36-R43) [[2]](diffhunk://#diff-ab0faaa95c1eeb24bef7127fa48292fc4e1eea76fbe8c6920fbce429ad014e34L57-R57) [[3]](diffhunk://#diff-27cbd60520b1f2192e8ae54573cb7183146b7e872274ea62bbf8a64a16be8315L9-R9)